### PR TITLE
Update Maven GitHub Action with Temurin

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
The AdoptOpenJDK Java distribution is being migrated to Eclipse Temurin. It is recommended to switch to use the latest distribution. More information: https://github.com/actions/setup-java#supported-distributions